### PR TITLE
Set CPU explicitly

### DIFF
--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -6,7 +6,7 @@ locals {
 
   datadog_agent_cpu = 100
   log_router_cpu    = 100
-  application_cpu   = var.cpu - datadog_agent_cpu - log_router_cpu
+  application_cpu   = var.cpu - local.datadog_agent_cpu - local.log_router_cpu
 }
 
 #########################################

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -25,7 +25,7 @@ variable "cpu" {
   description = "The amount of CPU available to one instance of your service (a small fraction will be used for the sidecar containers that are responsible for monitoring)."
   validation {
     condition     = var.datadog_tags.environment >= 256
-    error_message = "The log-router and datadog-agent use 100 CPU each, so you probably need some extra CPU on top of this."
+    error_message = "The log-router and datadog-agent use 100 cpu units each. In addition, you need some cpu units for your application. So the minimum total cpu is 256."
   }
 }
 

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -23,6 +23,10 @@ variable "cpu" {
   type        = number
   default     = 2048
   description = "The amount of CPU available to one instance of your service (a small fraction will be used for the sidecar containers that are responsible for monitoring)."
+  validation {
+    condition     = var.datadog_tags.environment >= 256
+    error_message = "The log-router and datadog-agent use 100 CPU each, so you probably need some extra CPU on top of this."
+  }
 }
 
 variable "memory" {

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -24,7 +24,7 @@ variable "cpu" {
   default     = 2048
   description = "The amount of CPU available to one instance of your service (a small fraction will be used for the sidecar containers that are responsible for monitoring)."
   validation {
-    condition     = var.datadog_tags.environment >= 256
+    condition     = var.cpu >= 256
     error_message = "The log-router and datadog-agent use 100 cpu units each. In addition, you need some cpu units for your application. So the minimum total cpu is 256."
   }
 }


### PR DESCRIPTION
Set CPU explicitly on all containers. We do this to make it easier to understand how much CPU is available to the containers. Also, setting CPU to 0 means that fargate will distribute the remaining cpu evenly between the containers. However, we want to use most of the cpu units for the application.