### PR TITLE
Lower cpu on log-router and datadog-agent

### DIFF
--- a/spring-boot-service/README.md
+++ b/spring-boot-service/README.md
@@ -51,3 +51,4 @@ module "spring_boot_service" {
   }
 }
 ```
+

--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -4,8 +4,8 @@ locals {
   service_account_id   = "184465511165"
   internal_domain_name = "${var.name}.${local.shared_config.internal_hosted_zone_name}"
 
-  datadog_agent_cpu = 100
-  log_router_cpu    = 100
+  datadog_agent_cpu = 64
+  log_router_cpu    = 64
   application_cpu   = var.cpu - local.datadog_agent_cpu - local.log_router_cpu
 }
 

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -25,7 +25,7 @@ variable "cpu" {
   description = "The amount of CPU available to one instance of your service (a small fraction will be used for the sidecar containers that are responsible for monitoring)."
   validation {
     condition     = var.cpu >= 256
-    error_message = "The log-router and datadog-agent use 100 cpu units each. In addition, you need some cpu units for your application. So the minimum total cpu is 256."
+    error_message = "The log-router and datadog-agent use 64 cpu units each. In addition, you need some cpu units for your application. So the minimum total cpu is 256."
   }
 }
 


### PR DESCRIPTION
# Background
Tested running the log-router and datadog-agent with 100 cpu units. The datadog-agent was running on approximately 20% of this and the log-router was running on less.

# Solution
Set 64 cpu units for log-router and datadog-agent because because 100 is a bit much, 20 (that the datadog-agent was running on previously) is a bit low, and because 1/8 vCPU is a nice number.
