### PR TITLE
New datadog-agent port mapping + Datadog Agent toggle

### DIFF
--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -44,7 +44,7 @@ locals {
         {
           containerPort = 8126
           hostPort      = 8126
-          protocol      = "udp"
+          protocol      = "tcp"
         }
       ]
     }

--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -9,6 +9,8 @@ locals {
   application_cpu           = var.cpu - local.datadog_agent_cpu - local.log_router_cpu
   datadog_agent_soft_memory = 256
   log_router_soft_memory    = 100
+
+  java_tool_options = var.datadog_agent_enabled ? "-javaagent:/application/dd-java-agent.jar ${var.extra_java_tool_options}" : var.extra_java_tool_options
 }
 
 #########################################
@@ -25,6 +27,7 @@ resource "terraform_data" "no_spot_in_prod" {
     }
   }
 }
+
 module "task" {
   source                = "github.com/nsbno/terraform-aws-ecs-service?ref=0.13.0"
   depends_on            = [terraform_data.no_spot_in_prod]
@@ -51,7 +54,7 @@ module "task" {
         DD_VERSION           = var.datadog_tags.version
         DD_LOGS_INJECTION    = "true"
         DD_TRACE_SAMPLE_RATE = "1"
-        JAVA_TOOL_OPTIONS    = "-javaagent:/application/dd-java-agent.jar ${var.extra_java_tool_options}"
+        JAVA_TOOL_OPTIONS    = local.java_tool_options
       },
       var.environment_variables
     )
@@ -94,40 +97,41 @@ module "task" {
     target_value = tostring(var.autoscaling.target)
   }
 
-  sidecar_containers = [
-    {
-      name              = "datadog-agent"
-      image             = "datadog/agent:latest"
-      cpu               = local.datadog_agent_cpu
-      memory_soft_limit = local.datadog_agent_soft_memory
+  sidecar_containers = concat(
+    var.datadog_agent_enabled ? [
+      {
+        name              = "datadog-agent"
+        image             = "datadog/agent:latest"
+        cpu               = local.datadog_agent_cpu
+        memory_soft_limit = local.datadog_agent_soft_memory
 
-      environment = {
-        DD_ENV                         = var.datadog_tags.environment
-        DD_SERVICE                     = var.name
-        ECS_FARGATE                    = "true"
-        DD_SITE                        = "datadoghq.eu"
-        DD_APM_ENABLED                 = "true"
-        DD_APM_IGNORE_RESOURCES        = "/health"
-        DD_DOGSTATSD_NON_LOCAL_TRAFFIC = "true"
-        DD_CHECKS_TAG_CARDINALITY      = "orchestrator"
-        DD_DOGSTATSD_TAG_CARDINALITY   = "orchestrator"
-      }
+        environment = {
+          DD_ENV                         = var.datadog_tags.environment
+          DD_SERVICE                     = var.name
+          ECS_FARGATE                    = "true"
+          DD_SITE                        = "datadoghq.eu"
+          DD_APM_ENABLED                 = "true"
+          DD_APM_IGNORE_RESOURCES        = "/health"
+          DD_DOGSTATSD_NON_LOCAL_TRAFFIC = "true"
+          DD_CHECKS_TAG_CARDINALITY      = "orchestrator"
+          DD_DOGSTATSD_TAG_CARDINALITY   = "orchestrator"
+        }
 
-      secrets = {
-        DD_API_KEY = data.aws_ssm_parameter.datadog_apikey.arn,
-      }
+        secrets = {
+          DD_API_KEY = data.aws_ssm_parameter.datadog_apikey.arn,
+        }
 
-      extra_options = {
-        mountPoints = []
-        volumesFrom = []
-        portMappings = [{
-          containerPort = 8125
-          hostPort      = 8125
-          protocol      = "udp"
-        }]
-      }
-    },
-    {
+        extra_options = {
+          mountPoints = []
+          volumesFrom = []
+          portMappings = [{
+            containerPort = 8125
+            hostPort      = 8125
+            protocol      = "udp"
+          }]
+        }
+    }] : [],
+    [{
       name              = "log-router"
       image             = nonsensitive(data.aws_ssm_parameter.log_router_image.value)
       essential         = true
@@ -147,8 +151,8 @@ module "task" {
           }
         }
       }
-    }
-  ]
+    }]
+  )
 
   lb_health_check = {
     port = var.port

--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -19,9 +19,9 @@ locals {
     environment = {
       DD_ENV                         = var.datadog_tags.environment
       DD_SERVICE                     = var.name
-      ECS_FARGATE                    = var.datadog_disable_fargate ? "false" : "true"
+      ECS_FARGATE                    = "true"
       DD_SITE                        = "datadoghq.eu"
-      DD_APM_ENABLED                 = var.datadog_disable_apm ? "false" : "true"
+      DD_APM_ENABLED                 = "true"
       DD_APM_IGNORE_RESOURCES        = "/health"
       DD_DOGSTATSD_NON_LOCAL_TRAFFIC = "true"
       DD_CHECKS_TAG_CARDINALITY      = "orchestrator"

--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -114,7 +114,10 @@ module "task" {
         DD_VERSION           = var.datadog_tags.version
         DD_LOGS_INJECTION    = "true"
         DD_TRACE_SAMPLE_RATE = "1"
-        JAVA_TOOL_OPTIONS    = var.disable_datadog_agent ? var.extra_java_tool_options : "-javaagent:/application/dd-java-agent.jar ${var.extra_java_tool_options}"
+
+        JAVA_TOOL_OPTIONS = var.disable_datadog_agent ? var.extra_java_tool_options : "-javaagent:/application/dd-java-agent.jar ${var.extra_java_tool_options}"
+
+        VY_DATADOG_AGENT_ENABLED = var.disable_datadog_agent ? "false" : "true"
       },
       var.environment_variables
     )

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -101,5 +101,5 @@ variable "datadog_tags" {
 variable "disable_datadog_agent" {
   type        = bool
   default     = false
-  description = "No metrics will appear in Disable the DataDog agent. Used for saving money in DataDog. The VY_DATADOG_AGENT_ENABLED environment variable is set to 'true' or 'false' in the application container."
+  description = "Disable the DataDog agent. Disables metrics and APM in DataDog. Used for saving money in DataDog. The VY_DATADOG_AGENT_ENABLED environment variable is set to 'true' or 'false' in the application container."
 }

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -35,18 +35,6 @@ variable "memory" {
   description = "The amount of memory available to one instance of your service (a small fraction will be used for the sidecar containers that are responsible for monitoring)."
 }
 
-variable "datadog_tags" {
-  type = object({
-    version     = string
-    environment = string
-  })
-  description = "All logs and traces in datadog should be tagged with version=<the short commit-sha> and environment=<name of environment>"
-  validation {
-    condition     = contains(["test", "stage", "prod"], var.datadog_tags.environment)
-    error_message = "datadog_tags.environment must be one of 'test', 'stage' and 'prod'."
-  }
-}
-
 variable "docker_image" {
   type        = string
   description = "The docker image of your service."
@@ -98,8 +86,26 @@ variable "wait_for_steady_state" {
   description = "Terraform waits until the new version of the task is rolled out and working, instead of exiting before the rollout."
 }
 
-variable "datadog_agent_enabled" {
+variable "datadog_tags" {
+  type = object({
+    version     = string
+    environment = string
+  })
+  description = "All logs and traces in datadog should be tagged with version=<the short commit-sha> and environment=<name of environment>"
+  validation {
+    condition     = contains(["test", "stage", "prod"], var.datadog_tags.environment)
+    error_message = "datadog_tags.environment must be one of 'test', 'stage' and 'prod'."
+  }
+}
+
+variable "datadog_disable_fargate" {
   type        = bool
-  default     = true
-  description = ""
+  default     = false
+  description = "Disable fargate metrics in DataDog"
+}
+
+variable "datadog_disable_apm" {
+  type        = bool
+  default     = false
+  description = "Disable APM in DataDog"
 }

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -97,3 +97,9 @@ variable "wait_for_steady_state" {
   default     = true
   description = "Terraform waits until the new version of the task is rolled out and working, instead of exiting before the rollout."
 }
+
+variable "datadog_agent_enabled" {
+  type        = bool
+  default     = true
+  description = ""
+}

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -101,5 +101,5 @@ variable "datadog_tags" {
 variable "disable_datadog_agent" {
   type        = bool
   default     = false
-  description = "No metrics will appear in Disable the DataDog agent. Used for saving money in DataDog."
+  description = "No metrics will appear in Disable the DataDog agent. Used for saving money in DataDog. The VY_DATADOG_AGENT_ENABLED environment variable is set to 'true' or 'false' in the application container."
 }

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -98,14 +98,8 @@ variable "datadog_tags" {
   }
 }
 
-variable "datadog_disable_fargate" {
+variable "disable_datadog_agent" {
   type        = bool
   default     = false
-  description = "Disable fargate metrics in DataDog"
-}
-
-variable "datadog_disable_apm" {
-  type        = bool
-  default     = false
-  description = "Disable APM in DataDog"
+  description = "No metrics will appear in Disable the DataDog agent. Used for saving money in DataDog."
 }


### PR DESCRIPTION
## Background
1. Warning logs that complains about not being able to send metrics to `localhost:8126`.
2. We are a little bit over the limit on fargate tasks in DataDog.

## Solution
1. Add port mapping for `8126/tcp` to the datadog agent. There is no documentation that mentions both ports at the same time, but both ports are mentioned seperately.
2. The fargate task does not appear in DataDog if we run without the datadog agent sidecar. Create flag that disables the datadog agent sidecar. Also set the `VT_DATADOG_AGENT_ENABLED` environment variable so applications can disable metrics if there is no datadog agent to send them to.

## TODO
- [x] ~Test if fargate task is still in datadog if `DD_APM_ENABLED` and `ECS_FARGATE` are set to `false`. Maybe it is not necessary to remove the sidecar. In this case, we would keep custom metrics.~ I have only been able to remove the Fargate task from DataDog when removing the datadog-agent.