### PR TITLE
[major] Remove name prefix in the spring-boot-service module

### DIFF
--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -1,5 +1,4 @@
 locals {
-  name_prefix          = "digitalekanaler"
   shared_config        = nonsensitive(jsondecode(data.aws_ssm_parameter.shared_config.value))
   service_account_id   = "184465511165"
   internal_domain_name = "${var.name}.${local.shared_config.internal_hosted_zone_name}"
@@ -91,7 +90,7 @@ resource "terraform_data" "no_spot_in_prod" {
 module "task" {
   source                = "github.com/nsbno/terraform-aws-ecs-service?ref=0.13.0"
   depends_on            = [terraform_data.no_spot_in_prod]
-  application_name      = "${local.name_prefix}-${var.name}"
+  application_name      = var.name
   vpc_id                = local.shared_config.vpc_id
   private_subnet_ids    = local.shared_config.private_subnet_ids
   cluster_id            = var.use_spot ? local.shared_config.ecs_spot_cluster_id : local.shared_config.ecs_cluster_id
@@ -101,7 +100,7 @@ module "task" {
   wait_for_steady_state = var.wait_for_steady_state
 
   application_container = {
-    name     = "${local.name_prefix}-${var.name}"
+    name     = var.name
     image    = var.docker_image
     port     = var.port
     protocol = "HTTP"
@@ -200,11 +199,11 @@ module "task" {
 #                                       #
 #########################################
 resource "aws_kms_key" "application_key" {
-  description = "Key for ${local.name_prefix}-${var.name}"
+  description = "Key for ${var.name}"
 }
 
 resource "aws_kms_alias" "application_key_alias" {
-  name          = "alias/${local.name_prefix}-${var.name}"
+  name          = "alias/${var.name}"
   target_key_id = aws_kms_key.application_key.id
 }
 
@@ -235,8 +234,8 @@ data "aws_iam_policy_document" "fargate_task_policy_document" {
 }
 
 resource "aws_iam_policy" "fargate_task_policy" {
-  name        = "${local.name_prefix}-${var.name}-fargate-task-policy"
-  description = "Policy for ${local.name_prefix}-${var.name} to read secrets"
+  name        = "${var.name}-fargate-task-policy"
+  description = "Policy for ${var.name} to read secrets"
   policy      = data.aws_iam_policy_document.fargate_task_policy_document.json
 }
 


### PR DESCRIPTION
There are subtle differences in which services use the name prefix `digitalekanaler`. Also, within each services, there might be differences in which resources use the name prefix. If the service does not use the name prefix, migrating to the module results in downtime. To make migrating to the module slightly simpler, remove the concept of the name prefix inside the module.