### PR TITLE
[minor] Port mapping and configuration of the datadog-agent sidecar

### DIFF
--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -27,6 +27,7 @@ locals {
       DD_DOGSTATSD_NON_LOCAL_TRAFFIC = "true"
       DD_CHECKS_TAG_CARDINALITY      = "orchestrator"
       DD_DOGSTATSD_TAG_CARDINALITY   = "orchestrator"
+      DD_CMD_PORT                    = tostring(var.datadog_agent_cmd_port)
     }
 
     secrets = {
@@ -34,20 +35,8 @@ locals {
     }
 
     extra_options = {
-      mountPoints = []
-      volumesFrom = []
-      portMappings = [
-        {
-          containerPort = 8125
-          hostPort      = 8125
-          protocol      = "udp"
-        },
-        {
-          containerPort = 8126
-          hostPort      = 8126
-          protocol      = "tcp"
-        }
-      ]
+      mountPoints    = []
+      volumesFrom    = []
       systemControls = []
     }
   }
@@ -149,8 +138,8 @@ module "task" {
           valueFrom = data.aws_ssm_parameter.datadog_apikey.arn
         }]
       }
-      mountPoints = []
-      volumesFrom = []
+      mountPoints    = []
+      volumesFrom    = []
       systemControls = []
     }
   }

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -109,3 +109,8 @@ variable "disable_datadog_agent" {
   default     = false
   description = "Disable the DataDog agent. Disables metrics and APM in DataDog. Used for saving money in DataDog. The VY_DATADOG_AGENT_ENABLED environment variable is set to 'true' or 'false' in the application container."
 }
+
+variable "datadog_agent_cmd_port" {
+  type    = number
+  default = 5001
+}


### PR DESCRIPTION
This PR consists of two changes related to the ports that the datadog agent runs on:
- **Remove port mappings from the datadog-agent sidecar**
Containers inside the same fargate task can communicate over localhost without any port mappings ([docs](https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/fargate-security-considerations.html)). We do not need port mappings for the datadog agent because these ports are already available on `localhost:8125` and `localhost:8126` for the application container.
- **Make it possible to set the DD_CMD_PORT environment variable for the datadog-agent sidecar**
We have one service that runs on a port that conflicts with one of the ports that the datadog-agent runs on.