### PR TITLE
[major]Adjust default behavior for timeouts, grace periods and health checks.

### DIFF
--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -1,6 +1,5 @@
 locals {
   shared_config        = nonsensitive(jsondecode(data.aws_ssm_parameter.shared_config.value))
-  service_account_id   = "184465511165"
   internal_domain_name = "${var.name}.${local.shared_config.internal_hosted_zone_name}"
 
   datadog_agent_cpu         = 64
@@ -113,7 +112,7 @@ module "task" {
   }
 
   application_container = {
-    name     = "${local.name_with_prefix}"
+    name     = local.name_with_prefix
     image    = var.docker_image
     port     = var.port
     protocol = "HTTP"

--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -41,12 +41,23 @@ locals {
       volumesFrom    = []
       systemControls = []
     }
+
+    health_check = {
+      retries : 3,
+      timeout : 5,
+      interval : 10,
+      startPeriod : 15
+      command = [
+        "CMD-SHELL",
+        "agent health"
+      ]
+    }
   }
 
   log_router_sidecar_container = {
     name              = "log-router"
     image             = nonsensitive(data.aws_ssm_parameter.log_router_image.value)
-    essential         = true
+    essential         = false
     cpu               = local.log_router_cpu
     memory_soft_limit = local.log_router_soft_memory
 
@@ -83,16 +94,23 @@ resource "terraform_data" "no_spot_in_prod" {
 }
 
 module "task" {
-  source                = "github.com/nsbno/terraform-aws-ecs-service?ref=0.13.0"
-  depends_on            = [terraform_data.no_spot_in_prod]
-  application_name      = local.name_with_prefix
-  vpc_id                = local.shared_config.vpc_id
-  private_subnet_ids    = local.shared_config.private_subnet_ids
-  cluster_id            = var.use_spot ? local.shared_config.ecs_spot_cluster_id : local.shared_config.ecs_cluster_id
-  use_spot              = var.use_spot
-  cpu                   = var.cpu
-  memory                = var.memory
-  wait_for_steady_state = var.wait_for_steady_state
+  source             = "github.com/nsbno/terraform-aws-ecs-service?ref=0.14.3"
+  depends_on         = [terraform_data.no_spot_in_prod]
+  application_name   = local.name_with_prefix
+  vpc_id             = local.shared_config.vpc_id
+  private_subnet_ids = local.shared_config.private_subnet_ids
+  cluster_id         = var.use_spot ? local.shared_config.ecs_spot_cluster_id : local.shared_config.ecs_cluster_id
+  use_spot           = var.use_spot
+  cpu                = var.cpu
+  memory             = var.memory
+
+  wait_for_steady_state             = var.wait_for_steady_state
+  health_check_grace_period_seconds = var.health_check_grace_period_seconds
+  ecs_service_timeouts = {
+    create = var.service_timeouts.create
+    update = var.service_timeouts.update
+    delete = var.service_timeouts.delete
+  }
 
   application_container = {
     name     = "${local.name_with_prefix}"
@@ -101,15 +119,15 @@ module "task" {
     protocol = "HTTP"
     cpu      = local.application_cpu
     health_check = var.health_check_override == null ? null : {
-              retries: 5,
-              command: [
-                  "CMD-SHELL",
-                  "wget --no-verbose --tries=1 --spider http://localhost:${var.port}/health || exit 1"
-              ],
-              timeout: var.health_check_override.timeout,
-              interval: var.health_check_override.interval,
-              startPeriod: try(var.health_check_override.startPeriod, null)
-          }
+      retries : 5,
+      command : [
+        "CMD-SHELL",
+        "wget --no-verbose --tries=1 --spider http://localhost:${var.port}/health || exit 1"
+      ],
+      timeout : var.health_check_override.timeout,
+      interval : var.health_check_override.interval,
+      startPeriod : try(var.health_check_override.startPeriod, null)
+    }
 
     environment = merge(
       {
@@ -171,9 +189,12 @@ module "task" {
   )
 
   lb_health_check = {
-    port = var.port
-    path = "/health"
+    port              = var.port
+    path              = "/health"
+    interval          = 10
+    healthy_threshold = 2
   }
+  lb_deregistration_delay = var.lb_deregistration_delay
 
   lb_listeners = concat(
     var.deprecated_public_domain_name == null ? [] : [

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -124,10 +124,41 @@ variable "custom_api_gateway_path" {
 
 variable "health_check_override" {
   type = object({
-    interval = number
-    timeout = number
-    startPeriod = optional(number, null)
+    interval    = optional(number)
+    timeout     = optional(number)
+    startPeriod = optional(number)
   })
-  default = null
+  default = {
+    interval    = 5
+    timeout     = 2
+    startPeriod = 90
+  }
   description = "Override default health check parameters. This adds health check in ECS in addition to the load balancer, and can speed up your deployment"
+}
+
+variable "health_check_grace_period_seconds" {
+  type        = number
+  default     = 90
+  description = "The time that ECS waits before it starts checking the health of the new task."
+}
+
+variable "lb_deregistration_delay" {
+  type        = number
+  default     = 30
+  description = "The time that the load balancer waits before it deregisters a running task."
+
+}
+
+variable "service_timeouts" {
+  type = object({
+    create = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+  default = {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+  description = "Timeouts for the service resource."
 }

--- a/spring-boot-service/variables.tf
+++ b/spring-boot-service/variables.tf
@@ -146,7 +146,6 @@ variable "lb_deregistration_delay" {
   type        = number
   default     = 30
   description = "The time that the load balancer waits before it deregisters a running task."
-
 }
 
 variable "service_timeouts" {
@@ -156,9 +155,9 @@ variable "service_timeouts" {
     delete = optional(string)
   })
   default = {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
+    create = "6m"
+    update = "6m"
+    delete = "6m"
   }
   description = "Timeouts for the service resource."
 }


### PR DESCRIPTION
This is an opinionated module. We're doing some adjustments to timeouts and health checks to increase the insight into the service. It should also recover faster from a failing pipeline and hopefully deploy a little bit faster as well. 

MAJOR release, since this can strongly affect the runtime