### PR TITLE
revision  config name test value

### DIFF
--- a/apprunner-internal/main.tf
+++ b/apprunner-internal/main.tf
@@ -106,7 +106,7 @@ resource "aws_apprunner_vpc_connector" "service" {
 }
 
 resource "aws_apprunner_auto_scaling_configuration_version" "autoscaling" {
-  auto_scaling_configuration_name = "limited-scaling"
+  auto_scaling_configuration_name = "limited-scaling-2"
   max_concurrency                 = var.auto_scaling.max_concurrency
   min_size                        = var.auto_scaling.min_instances
   max_size                        = var.auto_scaling.max_instances


### PR DESCRIPTION
AWS Aprunner autoscaling have a max o9f 5 revisions pr name (and a max of 10 names) [as seen here](https://docs.aws.amazon.com/apprunner/latest/dg/architecture.html#architecture.quotas)

Currently the module create a new revision every time we create a new service and therefore we can only have 5 apprunner services with the current setup.
