### PR TITLE
[patch] Update auto scaling configuration name

### DIFF
--- a/apprunner-internal/main.tf
+++ b/apprunner-internal/main.tf
@@ -106,7 +106,7 @@ resource "aws_apprunner_vpc_connector" "service" {
 }
 
 resource "aws_apprunner_auto_scaling_configuration_version" "autoscaling" {
-  auto_scaling_configuration_name = "limited-scaling"
+  auto_scaling_configuration_name = "${var.application_name}-limited-scaling"
   max_concurrency                 = var.auto_scaling.max_concurrency
   min_size                        = var.auto_scaling.min_instances
   max_size                        = var.auto_scaling.max_instances

--- a/apprunner-internal/main.tf
+++ b/apprunner-internal/main.tf
@@ -54,11 +54,14 @@ resource "aws_apprunner_service" "service" {
 
   auto_scaling_configuration_arn = aws_apprunner_auto_scaling_configuration_version.autoscaling.arn
 
-  network_configuration {
+  dynamic network_configuration {
+    for_each = var.use_vpc_connector ? aws_apprunner_vpc_connector.service : []
+    content {
     egress_configuration {
       egress_type       = "VPC"
       vpc_connector_arn = aws_apprunner_vpc_connector.service.arn
     }
+      }
   }
 }
 
@@ -100,6 +103,7 @@ resource "aws_security_group" "apprunner_security_group" {
 }
 
 resource "aws_apprunner_vpc_connector" "service" {
+  count              = var.use_vpc_connector ? 1 : 0
   vpc_connector_name = var.application_name
   subnets            = data.aws_subnets.private_subnets.ids
   security_groups    = [aws_security_group.apprunner_security_group.id]

--- a/apprunner-internal/main.tf
+++ b/apprunner-internal/main.tf
@@ -94,17 +94,6 @@ data "aws_subnets" "private_subnets" {
   }
 }
 
-data "aws_subnets" "public_subnets" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.shared.id]
-  }
-  tags = {
-    Tier = "Public"
-    Name = "shared-public"
-  }
-}
-
 resource "aws_security_group" "apprunner_security_group" {
   name   = "${var.application_name}-sg"
   vpc_id = data.aws_vpc.shared.id
@@ -112,7 +101,7 @@ resource "aws_security_group" "apprunner_security_group" {
 
 resource "aws_apprunner_vpc_connector" "service" {
   vpc_connector_name = var.application_name
-  subnets            = var.subnet_placement == "public" ? data.aws_subnets.public_subnets.ids : data.aws_subnets.private_subnets.ids
+  subnets            = data.aws_subnets.private_subnets.ids
   security_groups    = [aws_security_group.apprunner_security_group.id]
 }
 

--- a/apprunner-internal/variables.tf
+++ b/apprunner-internal/variables.tf
@@ -74,14 +74,3 @@ variable "environment" {
     error_message = "The only valid environments are test, stage, service and prod."
   }
 }
-
-variable "subnet_placement" {
-  type = string
-  description = "Which subnets to place the app in (public, private)"
-  default = "private"
-
-  validation {
-    condition = contains(["public", "private"], var.subnet_placement)
-    error_message = "The only valid subnets are public, or private"
-  }
-}

--- a/apprunner-internal/variables.tf
+++ b/apprunner-internal/variables.tf
@@ -74,3 +74,9 @@ variable "environment" {
     error_message = "The only valid environments are test, stage, service and prod."
   }
 }
+
+variable "use_vpc_connector" {
+  type = bool
+  description = "Whether or not to run the service in the private subnets of th shared vpc"
+  default = true
+}

--- a/apprunner-internal/variables.tf
+++ b/apprunner-internal/variables.tf
@@ -75,8 +75,13 @@ variable "environment" {
   }
 }
 
-variable "use_vpc_connector" {
-  type = bool
-  description = "Whether or not to run the service in the private subnets of th shared vpc"
-  default = true
+variable "subnet_placement" {
+  type = string
+  description = "Which subnets to place the app in (public, private)"
+  default = "private"
+
+  validation {
+    condition = contains(["public", "private"], var.subnet_placement)
+    error_message = "The only valid subnets are public, or private"
+  }
 }


### PR DESCRIPTION
Fix bug where we create auto scaling configurations with the same name for all our apprunner services.
We are limited to 5 instances of the same configuration (with the same name), therefore we prefix the configuration name with the application name