### PR TITLE
[patch] Fix syntax for api_gateway module source

### DIFF
--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -292,7 +292,7 @@ resource "aws_route53_record" "internal_vydev_io_record" {
 }
 
 module "api_gateway" {
-  source       = "github.com/nsbno/terraform-digitalekanaler-modules?ref=0.0.2/microservice-apigw-proxy"
+  source       = "github.com/nsbno/terraform-digitalekanaler-modules//microservice-apigw-proxy?ref=0.0.2"
   service_name = local.api_gateway_path
   domain_name  = local.internal_domain_name
   listener_arn = local.shared_config.lb_internal_listener_arn


### PR DESCRIPTION
The syntax is no longer supported in newer versions of Terraform.