### PR TITLE
[patch] Deactivate Datadog remote config

### DIFF
--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -19,16 +19,17 @@ locals {
     memory_soft_limit = local.datadog_agent_soft_memory
 
     environment = {
-      DD_ENV                         = var.datadog_tags.environment
-      DD_SERVICE                     = var.name
-      ECS_FARGATE                    = "true"
-      DD_SITE                        = "datadoghq.eu"
-      DD_APM_ENABLED                 = "true"
-      DD_APM_IGNORE_RESOURCES        = "/health"
-      DD_DOGSTATSD_NON_LOCAL_TRAFFIC = "true"
-      DD_CHECKS_TAG_CARDINALITY      = "orchestrator"
-      DD_DOGSTATSD_TAG_CARDINALITY   = "orchestrator"
-      DD_CMD_PORT                    = tostring(var.datadog_agent_cmd_port)
+      DD_ENV                          = var.datadog_tags.environment
+      DD_SERVICE                      = var.name
+      ECS_FARGATE                     = "true"
+      DD_SITE                         = "datadoghq.eu"
+      DD_APM_ENABLED                  = "true"
+      DD_APM_IGNORE_RESOURCES         = "/health"
+      DD_DOGSTATSD_NON_LOCAL_TRAFFIC  = "true"
+      DD_CHECKS_TAG_CARDINALITY       = "orchestrator"
+      DD_DOGSTATSD_TAG_CARDINALITY    = "orchestrator"
+      DD_CMD_PORT                     = tostring(var.datadog_agent_cmd_port)
+      DD_REMOTE_CONFIGURATION_ENABLED = false
     }
 
     secrets = {


### PR DESCRIPTION
Newer versions of Datadog agent  has remote configuration enabled by default. This generate thousands  
of unnecessary warnings since remote configuration is not setup in our organization. 