### PR TITLE
[skip ci] Bump ECS service module version to 3.4.1 to fix deployment error

### DIFF
--- a/spring-boot-service/main.tf
+++ b/spring-boot-service/main.tf
@@ -27,7 +27,7 @@ resource "terraform_data" "no_spot_in_prod" {
 }
 
 module "task" {
-  source                          = "github.com/nsbno/terraform-aws-ecs-service?ref=3.4.0"
+  source                          = "github.com/nsbno/terraform-aws-ecs-service?ref=3.4.1"
   depends_on                      = [terraform_data.no_spot_in_prod]
   service_name                    = local.name_with_prefix
   vpc_id                          = local.shared_config.vpc_id


### PR DESCRIPTION
See release note for details:
https://github.com/nsbno/terraform-aws-ecs-service/releases/tag/3.4.1
